### PR TITLE
window object for commonjs enviroments in IE8

### DIFF
--- a/eventie.js
+++ b/eventie.js
@@ -9,7 +9,7 @@
 /*jshint browser: true, undef: true, unused: true */
 /*global define: false, module: false */
 
-( function( window ) {
+( function() {
 
 'use strict';
 
@@ -79,4 +79,4 @@ if ( typeof define === 'function' && define.amd ) {
   window.eventie = eventie;
 }
 
-})( this );
+})();


### PR DESCRIPTION
In commonjs environments this refers to an empty object and not the window object. IE8 fails with an error.
