### PR TITLE
Add spm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Install with [Bower :bird:](http://bower.io) `bower install eventie`
 
 Install with npm :truck: `npm install eventie`
 
+Install with [spm](http://spmjs.io/package/eventie) [![](http://spmjs.io/badge/eventie)](http://spmjs.io/package/eventie) `spm install eventie`
+
 Install with [Component :nut_and_bolt:](https://github.com/component/component) `component install desandro/eventie`
 
 ## IE 8

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "DOM",
     "event"
   ],
-  "author": "David DeSandro"
+  "author": "David DeSandro",
+  "spm": {
+    "main": "eventie.js"
+  }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/eventie

---

It is a browser side package manager popular in China. It supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of eventie in spmjs, I can add it for your account after signing in http://spmjs.io.
