### PR TITLE
www: Fix global references

### DIFF
--- a/eventie.js
+++ b/eventie.js
@@ -13,6 +13,10 @@
 
 'use strict';
 
+if ( !window.document ) {
+    return;
+}
+
 var docElem = document.documentElement;
 
 var bind = function() {};
@@ -79,4 +83,4 @@ if ( typeof define === 'function' && define.amd ) {
   window.eventie = eventie;
 }
 
-})( window );
+})( typeof window !== "undefined" ? window : this );


### PR DESCRIPTION
Hi @desandro.

This is the sister PR for https://github.com/desandro/imagesloaded/pull/178.

Because **eventie** is a dependency for **imagesloaded** I was hoping to get this change in to support bundling imagesloaded for server-side rendering with browserify. See [the other PR](/desandro/imagesloaded/pull/178) for more details.

Thanks again.
